### PR TITLE
Don't preload packs if replay viewer is enabled

### DIFF
--- a/compat/game192/assets.lua
+++ b/compat/game192/assets.lua
@@ -1,6 +1,7 @@
 local async = require("async")
 local audio = require("audio")
 local threadify = require("threadify")
+local args = require("args")
 local threaded_assets = threadify.require("game_handler.assets")
 
 local assets = {}
@@ -22,7 +23,7 @@ local pending_packs = {}
 
 assets.init = async(function(config)
     sound_volume = config.get("sound_volume")
-    if config.get("preload_all_packs") then
+    if config.get("preload_all_packs") and not args.replay_viewer then
         local game_handler = require("game_handler")
         local packs = game_handler.get_packs()
         for i = 1, #packs do

--- a/compat/game20/assets.lua
+++ b/compat/game20/assets.lua
@@ -2,6 +2,7 @@ local threadify = require("threadify")
 local threaded_assets = threadify.require("game_handler.assets")
 local async = require("async")
 local audio = require("audio")
+local args = require("args")
 local assets = {}
 local sound_volume
 local sound_path = "assets/audio/"
@@ -11,7 +12,7 @@ local pending_packs = {}
 
 assets.init = async(function(config)
     sound_volume = config.get("sound_volume")
-    if config.get("preload_all_packs") then
+    if config.get("preload_all_packs") and not args.replay_viewer then
         local game_handler = require("game_handler")
         local packs = game_handler.get_packs()
         for i = 1, #packs do

--- a/compat/game21/assets.lua
+++ b/compat/game21/assets.lua
@@ -42,7 +42,7 @@ end
 
 assets.init = async(function(config)
     sound_volume = config.get("sound_volume")
-    if config.get("preload_all_packs") then
+    if config.get("preload_all_packs") and not args.replay_viewer then
         local game_handler = require("game_handler")
         local packs = game_handler.get_packs()
         for i = 1, #packs do


### PR DESCRIPTION
I added a simple optimization that doesn't preload packs when replay viewer ("--replay-viewer" flag) is enabled.

Optimization is significant when there's a lot of level packs installed, because if you're loading a replay with the flag passed in, why load every pack in the background if you're on a level which exits after its done? just load one pack with the replay's level and that's it. no unnecessary preloading.